### PR TITLE
Fix broken links with external urls

### DIFF
--- a/renderers/BaseRenderer.php
+++ b/renderers/BaseRenderer.php
@@ -220,6 +220,11 @@ abstract class BaseRenderer extends Component
      */
     public function generateGuideUrl($file)
     {
+        //skip parsing external url
+        if ( (strpos($file, 'https://') !== false) || (strpos($file, 'http://') !== false) ) {
+            return $file;
+        }
+     
         $hash = '';
         if (($pos = strpos($file, '#')) !== false) {
             $hash = substr($file, $pos);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | not tested |
| Fixed issues | #9922 |

When an url in the guide is refering to an url out of the guide project itself, avoid parsing url to keep it working (used in side nav bar).

Example:
[Advanced Project Template](https://github.com/yiisoft/yii2-app-advanced/blob/master/docs/guide/README.md)
